### PR TITLE
[Draft] m1-fixed-gem-versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:2.6.6
 RUN apt-get update && apt-get install -y cmake
+RUN gem install -N pronto-rubocop -v 0.10.0
 COPY Gemfile Gemfile
-RUN gem install specific_install
-RUN gem specific_install https://github.com/prontolabs/pronto-rubocop.git
 RUN bundle install
 CMD git fetch origin master && pronto run -c origin/master --exit-code

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'pronto', '~> 0.10.0', require: false
-gem 'rubocop', '~> 1.4.1', require: false
-gem 'rubocop-performance', require: false
-gem 'rubocop-rails', require: false
+gem 'pronto', '0.10.0', require: false
+gem 'rubocop', '1.4.2', require: false
+gem 'rubocop-ast', '1.2.0', require: false
+gem 'rubocop-performance', '1.9.0', require: false
+gem 'rubocop-rails', '2.8.1', require: false


### PR DESCRIPTION
All gem versions from current sinlead/drone-pronto:v1.1.2 image
For mac m1 users
``` sh
# At repo root
docker build .
docker tag [image id you just build] sinlead/drone-pronto:v1.1.2
```