### PR TITLE
Upgrade gem versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6
+FROM ruby:3.2.2
 RUN apt-get update && apt-get install -y cmake
 COPY Gemfile Gemfile
 RUN gem install specific_install

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,7 +1,0 @@
-FROM --platform=linux/amd64 ruby:2.6
-RUN apt-get update && apt-get install -y cmake
-COPY Gemfile Gemfile
-RUN gem install specific_install
-RUN gem specific_install https://github.com/prontolabs/pronto-rubocop.git
-RUN bundle install
-CMD git fetch origin master && pronto run -c origin/master --exit-code

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'pronto', '~> 0.10.0', require: false
-gem 'rubocop', '~> 1.4.1', require: false
+gem 'pronto', '~> 0.11.1', require: false
+gem 'rubocop', '~> 1.51', require: false
 gem 'rubocop-performance', require: false
 gem 'rubocop-rails', require: false


### PR DESCRIPTION
說明:
1. 因原本 Gemfile 有指定 rubocop 版本，並不支援 Ruby 3.1 以上，故將 Gemfile 的 gem 升級到最新，支援到最新 3.2 (https://github.com/rubocop/rubocop/pull/10433)
2. 將 Dockerfile 的 ruby base 升級到最新 Ruby 3.2.2，在 ARM 架構 (ex: M1/M2 晶片) 已能直接使用，故將 `Dockerfile.arm64` 檔案刪除
3. 從 wms 準備升級 Ruby 到 3.1 時，CI 噴錯發現的 https://drone.sinlead.com/sinlead/wms/17145/6/3
wms PR: https://github.com/sinlead/wms/pull/4379
<img width="1362" alt="截圖 2023-05-17 上午10 12 23" src="https://github.com/sinlead/drone-pronto/assets/50837141/1ce11008-3db4-4d38-ac02-6b7423a3c71c">

4. 確認沒問題後，才會推新的 image 版本到 docker hub，預計要下的 code
```
$ docker buildx build --platform linux/amd64,linux/arm64 -t sinlead/drone-pronto:v1.3.0 --push .
```

---

## Local 測試
1. 在這支 branch 先 build image (`$ docker build .`)
2. 接著在 wms branch 跑該 image 檢查
```
$ docker images
$ git fetch origin master && docker run --rm -v $PWD:/data -w /data c1869630581e pronto run -c origin/master --exit-code
```

![截圖 2023-05-17 上午10 14 06](https://github.com/sinlead/drone-pronto/assets/50837141/2c3d2d78-1e7d-4f55-a66e-7331cb44796c)
